### PR TITLE
Added missing dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ private
 
 .DS_Store
 
+Tunnels-*-*

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var electron = require('electron-prebuilt')
+var path = require('path')
+var proc = require('child_process')
+
+var child = proc.spawn(electron, [path.join(__dirname, 'index.js')], {stdio: 'inherit'})
+child.on('close', function (code) {
+  process.exit(code)
+})

--- a/package.json
+++ b/package.json
@@ -29,20 +29,23 @@
     "test": "node test | faucet",
     "relib": "electron-rebuild",
     "lint": "eslint .",
-    "start": "electron ."
+    "start": "electron .",
+    "package:osx": "electron-packager ./ Tunnels --platform=darwin --arch=x64 --version=0.35.2"
   },
   "files": [
     "index.js",
     "src"
   ],
   "bin": {
-    "tunnels": "index.js"
+    "tunnels": "cli.js"
   },
   "eslintConfig": {
     "extends": "js"
   },
   "license": "MIT",
   "devDependencies": {
+    "electron-packager": "^5.1.1",
+    "electron-prebuilt": "^0.35.2",
     "tape": "^4.2.2"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -22,16 +22,16 @@
 npm install -g electron-tunnels
 ```
 
-> By now, [Electron](http://electron.atom.io/) is not bundled with the app,
-
-> you have to install it globally. This will change soon as we package tunnels
-
-> for the various platform.
+## Building
 
 ```bash
-npm install -g electron-prebuilt
+git clone git@github.com:parro-it/tunnels.git
+cd tunnels
+npm i
+npm run build:osx
+# or
+npm start
 ```
-
 
 ## Usage
 


### PR DESCRIPTION
Package.json should include as much of your dependencies as possible.  This adds electron-prebuilt and electron-packager, adds a build script example for osx, and adds a cli that works with the bundled dependencies.  

Nice work!
